### PR TITLE
Fix hardhat deploy script

### DIFF
--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -5,21 +5,26 @@ require("@nomicfoundation/hardhat-ethers");
 require("@nomiclabs/hardhat-etherscan");
 require("@nomicfoundation/hardhat-chai-matchers");
 
+const networks = {
+  hardhat: {
+    // You can keep or remove forking if you don’t need a local fork
+    forking: process.env.POLYGON_RPC_URL
+      ? { url: process.env.POLYGON_RPC_URL }
+      : undefined,
+  },
+};
+
+if (process.env.POLYGON_RPC_URL && process.env.PRIVATE_KEY) {
+  networks.polygon = {
+    url: process.env.POLYGON_RPC_URL,
+    accounts: [process.env.PRIVATE_KEY],
+    chainId: 137,
+  };
+}
+
 module.exports = {
   solidity: "0.8.28",
-  networks: {
-    hardhat: {
-      // You can keep or remove forking if you don’t need a local fork
-      forking: process.env.POLYGON_RPC_URL
-        ? { url: process.env.POLYGON_RPC_URL }
-        : undefined,
-    },
-    polygon: {
-      url: process.env.POLYGON_RPC_URL,
-      accounts: [process.env.PRIVATE_KEY],
-      chainId: 137,
-    },
-  },
+  networks,
   etherscan: {
     // Make sure you set POLYGONSCAN_API_KEY in your .env (not ETHERSCAN_API_KEY)
     apiKey: {

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -7,8 +7,9 @@ async function main() {
   // Change this to the V2 contract name
 const Token = await ethers.getContractFactory("SquirrelyTailsTokenV2");
 const token = await Token.deploy();
+await token.waitForDeployment();
 
-  console.log("Token deployed at:", token.address);
+  console.log("Token deployed at:", token.target);
 }
 
 main()


### PR DESCRIPTION
## Summary
- handle optional polygon network config
- use ethers v6 deployment helpers to print contract address

## Testing
- `npx hardhat compile`
- `npx hardhat run --network hardhat scripts/deploy.js`

------
https://chatgpt.com/codex/tasks/task_e_684223820b7c832e93f723b74b9de7eb